### PR TITLE
Docker の DB のポートマッピングの追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - CREDENTIALS_SOURCE # inherit
   postgres:
     image: postgres:alpine
+    ports:
+      - "5432:5432"
     hostname: postgres
     environment:
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
* DBeaver などで操作する際に DB のポートがホストマシンに側に転送されている必要があるため